### PR TITLE
add README file #2

### DIFF
--- a/study-sync-000/README.md
+++ b/study-sync-000/README.md
@@ -1,0 +1,7 @@
+# Elastic Beanstalk Follow Along
+
+## One video is missing
+
+In the Follow Along, the video explaining the Dockerfile creation is missing!!!
+
+Be sure to check [EB-Follow-Along-Docker](https://github.com/ExamProCo/TheFreeAWSDeveloperAssociate/tree/master/EB-Follow-Along-Docker) directory to catch up and finish the section.


### PR DESCRIPTION
It seems people are missing out the EB-Follow-Along-Docker directory you created.
I added another README on the `study-sync-000` directory to be more explicit.

<img width="825" alt="Capture d’écran 2020-04-09 à 22 04 39" src="https://user-images.githubusercontent.com/13972080/78936084-2ad93e80-7aae-11ea-9ee9-a540bb9ec372.png">
