### PR TITLE
move express dependency to correct place

### DIFF
--- a/study-sync-000/package.json
+++ b/study-sync-000/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "express": "^4.17.1"
   },
+  "devDependencies": {},
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I followed along with your excellent free video and came across some issues most probably due to changes made by AWS since you authored the video.

`002_node_command.config` is no longer needed and is replaced by having the correct references in `dependencies` and `scripts` in `package.json`. AWS will do a `npm install` and `npm start` for you.