### PR TITLE
Fix: Cloud9 free space error, change node version to alpine

### DIFF
--- a/EB-Follow-Along-Docker/Dockerfile
+++ b/EB-Follow-Along-Docker/Dockerfile
@@ -1,5 +1,5 @@
 # we'll use 10 since its same as Amazon Linux 1 default node version
-FROM node:10
+FROM node:10-alpine
 # where our app will be located in the image
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
I faced an issue building the docker image with the free tier server, the error was due to lack of free space (they might have changed how much space is allowed in the free tier? not sure)

I fixed the issue by defining the node version as alpine.